### PR TITLE
fix(installation): remove numpy update on installation attempt

### DIFF
--- a/avaframeConnector_provider.py
+++ b/avaframeConnector_provider.py
@@ -66,7 +66,7 @@ def find_python():
 try:
     import avaframe
 except ModuleNotFoundError:
-    subprocess.call(["pip3", "install", "--upgrade", "--user", "pandas", "numpy"])
+    # subprocess.call(["pip3", "install", "--upgrade", "--user", "pandas", "numpy"])
     subprocess.call(["pip3", "install", "avaframe", "--user"])
     try:
         import avaframe

--- a/metadata.txt
+++ b/metadata.txt
@@ -6,7 +6,7 @@
 name=AvaFrameConnector
 qgisMinimumVersion=3.18
 description=Connects to AvaFrame
-version=1.12
+version=1.12.1
 author=AvaFrame Team
 email=felix@avaframe.org
 
@@ -24,7 +24,8 @@ repository=https://github.com/avaframe/QGisAF
 
 hasProcessingProvider=yes
 # Uncomment the following line and add your changelog:
-changelog= 1.12 On Release area statics run, open parent folder on completion
+changelog= 1.12.1 Remove numpy update on installation
+    1.12 On Release area statics run, open parent folder on completion
     1.10 Add path generation tool, accept geotiff as raster input
     1.9 Add small ava to com2AB, fix deletion runOperational
     1.8 Add com6RockAvalanche, ana5PropAnaOnlyDirectory


### PR DESCRIPTION
The numpy update leads to an installation of numpy version 2.*, but this is a problem with current QGis releases (at least on windows) 